### PR TITLE
Fix og_access realm

### DIFF
--- a/og_access/og_access.module
+++ b/og_access/og_access.module
@@ -131,7 +131,7 @@ function og_access_node_access_records(NodeInterface $node) {
       $audience_helper = \Drupal::service('og.group_audience_helper');
       foreach ($audience_helper->getAllGroupAudienceFields('node', $node->getType()) as $field_name => $field) {
         foreach ($node->get($field_name)->referencedEntities() as $group) {
-          $list_gids[$group->getType][] = $group->id();
+          $list_gids[$group->getType()][] = $group->id();
         }
       }
 

--- a/og_access/og_access.module
+++ b/og_access/og_access.module
@@ -106,7 +106,7 @@ function og_access_node_access_records(NodeInterface $node) {
       $audience_helper = \Drupal::service('og.group_audience_helper');
       foreach ($audience_helper->getAllGroupAudienceFields('node', $node->getType()) as $field_name => $field) {
         foreach ($node->get($field_name)->referencedEntities() as $group) {
-          $list_gids[$group->getType()][] = $group->id();
+          $list_gids[$group->getEntityTypeId()][] = $group->id();
 
           if ($has_private) {
             // We already know we have a private group, so we can avoid
@@ -131,7 +131,7 @@ function og_access_node_access_records(NodeInterface $node) {
       $audience_helper = \Drupal::service('og.group_audience_helper');
       foreach ($audience_helper->getAllGroupAudienceFields('node', $node->getType()) as $field_name => $field) {
         foreach ($node->get($field_name)->referencedEntities() as $group) {
-          $list_gids[$group->getType()][] = $group->id();
+          $list_gids[$group->getEntityTypeId()][] = $group->id();
         }
       }
 

--- a/og_access/og_access.module
+++ b/og_access/og_access.module
@@ -106,7 +106,7 @@ function og_access_node_access_records(NodeInterface $node) {
       $audience_helper = \Drupal::service('og.group_audience_helper');
       foreach ($audience_helper->getAllGroupAudienceFields('node', $node->getType()) as $field_name => $field) {
         foreach ($node->get($field_name)->referencedEntities() as $group) {
-          $list_gids[$group->getType][] = $group->id();
+          $list_gids[$group->getType()][] = $group->id();
 
           if ($has_private) {
             // We already know we have a private group, so we can avoid


### PR DESCRIPTION
With the current og_access code, the realm for private content through og_access gets saved as "og_access:" in table {node_access}. With the proposed fix, this becomes "og_access:<node_type>".